### PR TITLE
Uninstall module used on PS 1.6 before using this one

### DIFF
--- a/ps_dataprivacy.php
+++ b/ps_dataprivacy.php
@@ -65,10 +65,11 @@ class Ps_Dataprivacy extends Module
         if (!$result) {
             return false;
         }
-        
+
         if (!$this->uninstallPrestaShop16Module()) {
             $this->installFixtures();
         }
+
         return true;
     }
 
@@ -91,12 +92,13 @@ class Ps_Dataprivacy extends Module
         if ($oldModule) {
             // This closure calls the parent class to prevent data to be erased
             // It allows the new module to be configured without migration
-            $parentUninstallClosure = function() {
+            $parentUninstallClosure = function () {
                 return parent::uninstall();
             };
             $parentUninstallClosure = $parentUninstallClosure->bindTo($oldModule, get_class($oldModule));
             $parentUninstallClosure();
         }
+
         return true;
     }
 


### PR DESCRIPTION
### How to test
1. Uninstall both `blockcustomerprivacy` & `ps_dataprivacy` if installed
2. Install [this modified version of `blockcustomerprivacy`](https://github.com/PrestaShop/ps_dataprivacy/files/6266420/blockcustomerprivacy.zip)
 (only the compatibility range has been changed to be able to install it on a 1.7 shop)
3. Install `ps_dataprivacy` with this PR
4. `blockcustomerprivacy` should now be uninstalled and `ps_dataprivacy` should be installed