### PR TITLE
Remove registration of unused hook

### DIFF
--- a/ps_dataprivacy.php
+++ b/ps_dataprivacy.php
@@ -58,9 +58,7 @@ class Ps_Dataprivacy extends Module
 
     public function install()
     {
-        $result = parent::install()
-            && $this->registerHook('additionalCustomerFormFields')
-            && $this->registerHook('actionSubmitAccountBefore');
+        $result = parent::install() && $this->registerHook('additionalCustomerFormFields');
 
         if (!$result) {
             return false;
@@ -76,7 +74,6 @@ class Ps_Dataprivacy extends Module
     public function uninstall()
     {
         return $this->unregisterHook('additionalCustomerFormFields')
-            && $this->unregisterHook('actionBeforeSubmitAccount')
             && parent::uninstall();
     }
 

--- a/ps_dataprivacy.php
+++ b/ps_dataprivacy.php
@@ -40,7 +40,7 @@ class Ps_Dataprivacy extends Module
     {
         $this->name = 'ps_dataprivacy';
         $this->author = 'PrestaShop';
-        $this->version = '2.0.1';
+        $this->version = '2.1.0';
         $this->need_instance = 0;
 
         $this->bootstrap = true;

--- a/upgrade/index.php
+++ b/upgrade/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * 2007-2020 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
+header("Last-Modified: ".gmdate("D, d M Y H:i:s")." GMT");
+
+header("Cache-Control: no-store, no-cache, must-revalidate");
+header("Cache-Control: post-check=0, pre-check=0", false);
+header("Pragma: no-cache");
+
+header("Location: ../");
+exit;

--- a/upgrade/index.php
+++ b/upgrade/index.php
@@ -23,13 +23,12 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
 
-header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
-header("Last-Modified: ".gmdate("D, d M Y H:i:s")." GMT");
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
 
-header("Cache-Control: no-store, no-cache, must-revalidate");
-header("Cache-Control: post-check=0, pre-check=0", false);
-header("Pragma: no-cache");
-
-header("Location: ../");
+header('Location: ../');
 exit;

--- a/upgrade/upgrade-2-1-0.php
+++ b/upgrade/upgrade-2-1-0.php
@@ -28,5 +28,5 @@ if (!defined('_PS_VERSION_')) {
 }
 function upgrade_module_2_1_0($object)
 {
-    return $object->unregisterHook('actionBeforeSubmitAccount');
+    return $object->unregisterHook('actionSubmitAccountBefore');
 }

--- a/upgrade/upgrade-2-1-0.php
+++ b/upgrade/upgrade-2-1-0.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * 2007-2020 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+function upgrade_module_2_1_0($object)
+{
+    return $object->unregisterHook('actionBeforeSubmitAccount');
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Deletion of unused hook, it is necessary because from Prestashop 1.7.8 all registered hooks in module must have a corresponding listener, otherwise they won't install in dev mode.
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Partly fixes #19230 & fixes https://github.com/PrestaShop/PrestaShop/issues/23708
| How to test?  | Test that module can still be installed without any problem

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
