### PR TITLE
Add _raw parameter on trans method to display not escaped html

### DIFF
--- a/ps_dataprivacy.php
+++ b/ps_dataprivacy.php
@@ -126,6 +126,7 @@ class Ps_Dataprivacy extends Module
         $label = $this->trans(
             'Customer data privacy[1][2]%message%[/2]',
             [
+                '_raw' => true,
                 '[1]' => '<br>',
                 '[2]' => '<em>',
                 '%message%' => Configuration::get('CUSTPRIV_MSG_AUTH', $this->context->language->id),


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Add _raw parameter on trans method to display not escaped html. This parameter will be available when https://github.com/PrestaShop/PrestaShop/pull/30415 will be merged
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/29940
| How to test?  | See https://github.com/PrestaShop/PrestaShop/pull/30415

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
